### PR TITLE
Raised maximum number of memory-mapped areas

### DIFF
--- a/debian/hardened_malloc.conf
+++ b/debian/hardened_malloc.conf
@@ -1,2 +1,2 @@
 ## https://github.com/GrapheneOS/hardened_malloc#traditional-linux-based-operating-systems
-vm.max_map_count = 524240
+vm.max_map_count = 1048576


### PR DESCRIPTION
Increased sysctl vm.max_map_count to the most up to date [recommendation](https://github.com/GrapheneOS/hardened_malloc#traditional-linux-based-operating-systems).

- Negligible (if any) impact on CPU usage, and
- Applications that tend to consume superfluous amounts of memory such as certain web browsers could potentially see a noticeable rise in RAM.

Therefore while more RAM might need to be allocated to certain VMs dependant on use case, the benefits of being able to accommodate more guard pages by default likely outweigh the cons.

